### PR TITLE
Fixed Elytra flight getting disabled

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/FlightManager.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/FlightManager.java
@@ -15,7 +15,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -176,7 +175,7 @@ public class FlightManager implements Listener {
         player.setAllowFlight(true);
         MessagingUtil.sendMessage(player, TextMode.Success, Messages.EnterFlightEnabled);
         Material below = player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType();
-        if (below == Material.AIR) {
+        if ((below == Material.AIR) && !player.isGliding()) {
             player.setFlying(true);
         }
     }


### PR DESCRIPTION
If a player is elytra flying through claim where the player is trusted and fly is enabled, elytra get disabled. fixed it by adding a check to see if player is gliding.