### PR TITLE
updated pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             <url>https://mvn.lumine.io/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>akiradev-repo</id>
-            <url>https://repo.luminescent.dev/repository/public/</url>
+            <id>elitemobs-repo</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <repository>
             <id>placeholderapi</id>
@@ -102,7 +102,8 @@
         <dependency>
             <groupId>com.magmaguy</groupId>
             <artifactId>EliteMobs</artifactId>
-            <version>8.0.2</version>
+            <version>8.7.4-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
- Updated the GriefPrevention id since its no longer under TechFortress.
- Updates GriefPrevention to v16.18.3

- Elitemobs has a dedicated repo now so no longer need Akiras.
- Updates EliteMobs to v8.7.4-SNAPSHOT