### PR TITLE
Add BetterReload Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
-        <!-- GriefPrevention Repo -->
+        <!-- GriefPrevention and BetterReload Repo -->
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
@@ -137,6 +137,12 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.amnoah.betterreload</groupId>
+            <artifactId>api</artifactId>
+            <version>v1.0.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/ryanhamshire/GPFlags/GPFlags.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/GPFlags.java
@@ -55,6 +55,10 @@ public class GPFlags extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new ClaimTransferListener(), this);
         Bukkit.getPluginManager().registerEvents(new FlightManager(), this);
 
+        if (Bukkit.getPluginManager().getPlugin("BetterReload") != null) {
+            Bukkit.getPluginManager().registerEvents(new ReloadListener(), this);
+        }
+
         this.flagsDataStore = new FlagsDataStore();
         reloadConfig();
 

--- a/src/main/java/me/ryanhamshire/GPFlags/listener/ReloadListener.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/listener/ReloadListener.java
@@ -1,0 +1,19 @@
+package me.ryanhamshire.GPFlags.listener;
+
+import better.reload.api.ReloadEvent;
+import me.ryanhamshire.GPFlags.GPFlags;
+import me.ryanhamshire.GPFlags.Messages;
+import me.ryanhamshire.GPFlags.TextMode;
+import me.ryanhamshire.GPFlags.util.MessagingUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ReloadListener implements Listener {
+
+    @EventHandler
+    private void onReload(ReloadEvent event) {
+        GPFlags.getInstance().reloadConfig();
+        GPFlags.getInstance().getFlagsDataStore().loadMessages();
+        MessagingUtil.sendMessage(event.getCommandSender(), TextMode.Success, Messages.ReloadComplete);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: GPFlags
 main: me.ryanhamshire.GPFlags.GPFlags
 depend: [GriefPrevention]
-softdepend: [mcMMO, Vault, MythicMobs, EliteMobs, PlaceholderAPI]
+softdepend: [mcMMO, Vault, MythicMobs, EliteMobs, PlaceholderAPI, BetterReload]
 authors: [Big_Scary, ShaneBee, DmitryRendov, DrBot]
 description: GriefPrevention add-on to set flags in claims.
 website: https://modrinth.com/plugin/gpflags


### PR DESCRIPTION
As an active developer for Minecraft plugins and as someone who helps many others with their servers via BirdFlop, I'm sure you know as well as I do that the Bukkit `/reload` command is fundamentally flawed and shouldn't be used. As such, this commit adds BetterReload support, hoping to help prevent the many issues that arise from the original command.

[BetterReload](https://github.com/amnoah/BetterReload) overrides the `/reload` command and sends out an event in its place that plugins can either handle or ignore. This leaves the reloading process up to plugins and leaves no sketchy behavior in the process.

For more information about BetterReload here are some links:
[Source Code](https://github.com/amnoah/BetterReload)
[Documentation](https://github.com/amnoah/BetterReload/wiki)
[Modrinth](https://modrinth.com/plugin/betterreload)

Thank you so much for your time, and have a great day!