### PR TITLE
Legacy support & Minimessage configuration options

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/FlagManager.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/FlagManager.java
@@ -2,6 +2,7 @@ package me.ryanhamshire.GPFlags;
 
 import com.google.common.io.Files;
 import me.ryanhamshire.GPFlags.flags.FlagDefinition;
+import me.ryanhamshire.GPFlags.util.ChatUtil;
 import me.ryanhamshire.GPFlags.util.MessagingUtil;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
@@ -116,8 +117,8 @@ public class FlagManager {
             }
             internalParameters.append(arg).append(" ");
         }
-        internalParameters = new StringBuilder(internalParameters.toString().trim());
-        friendlyParameters = new StringBuilder(friendlyParameters.toString().trim());
+        internalParameters = new StringBuilder(ChatUtil.validatedHexString(sender, internalParameters.toString()).trim());
+        friendlyParameters = new StringBuilder(ChatUtil.validatedHexString(sender, friendlyParameters.toString()).trim());
 
         SetFlagResult result;
         if (isActive) {

--- a/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
@@ -176,7 +176,7 @@ public class ChatUtil {
             boolean requiredChanges = false;
             String hexComponent = message.substring(matcher.start(), matcher.end());
             if (!sender.hasPermission("gpflags.messages.hex-colors")) {
-                message = message.replace(hexComponent, "<color:white>");
+                message = message.replace(hexComponent, "");
                 requiredChanges = true;
             }
             matcher = pattern.matcher(message);

--- a/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
@@ -11,12 +11,12 @@ public class ChatUtil {
     private static final MiniMessage minimessage = MiniMessage.builder().build();
 
     // Used to format chat-messages (legacy-support) of a specific sender related to his permissions
-    public static Component validatedHexComp(CommandSender sender, String message) {
+    public static String validatedHexString(CommandSender sender, String message) {
         message = message.replace("§", "&");
         message = parseHexColorCodes(message);
         message = parseEasyToComplex(message);
         message = validateMinimessage(sender, message);
-        return minimessage.deserialize(message);
+        return message;
     }
 
     // Used to format a chat-messages (legacy-support) without previous validation of somebody.

--- a/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
@@ -3,11 +3,8 @@ package me.ryanhamshire.GPFlags.util;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.md_5.bungee.api.ChatColor;
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -151,9 +148,27 @@ public class ChatUtil {
 
     private static String validateMinimessage(CommandSender sender, String message) {
 
-        // Check for click-components
-        Pattern pattern = Pattern.compile("<click:.*?>");
+        // Check if there is a link in the message without click-component
+        Pattern pattern = Pattern.compile("https?://\\S+");
         Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            boolean requiredChanges = false;
+            if(!sender.hasPermission("gpflags.messages.links")) {
+                message = message.replace(matcher.group(), "");
+                requiredChanges = true;
+            } else {
+                String link = message.substring(matcher.start(), matcher.end());
+                message = message.replace(link, "<click:open_url:" + link + ">" + link + "</click>");
+                matcher = pattern.matcher(message);
+            }
+            if (!requiredChanges) {
+                break;
+            }
+        }
+
+        // Check for click-components
+        pattern = Pattern.compile("<click:.*?>");
+        matcher = pattern.matcher(message);
         while (matcher.find()) {
             boolean requiredChanges = false;
             String clickComponent = message.substring(matcher.start(), matcher.end());
@@ -209,7 +224,7 @@ public class ChatUtil {
         while (matcher.find()) {
             boolean requiredChanges = false;
             String hexComponent = message.substring(matcher.start(), matcher.end());
-            if(!sender.hasPermission("gpflags.messages.hex-colors")) {
+            if (!sender.hasPermission("gpflags.messages.hex-colors")) {
                 message = message.replace(hexComponent, "<color:white>");
                 requiredChanges = true;
             }
@@ -227,7 +242,7 @@ public class ChatUtil {
         while (matcher.find()) {
             boolean requiredChanges = false;
             String colorComponent = message.substring(matcher.start(), matcher.end());
-            if(!sender.hasPermission("gpflags.messages.colors")) {
+            if (!sender.hasPermission("gpflags.messages.colors")) {
                 message = message.replace(colorComponent, "");
                 requiredChanges = true;
             }

--- a/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
@@ -2,7 +2,6 @@ package me.ryanhamshire.GPFlags.util;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import java.util.regex.Matcher;
@@ -11,41 +10,24 @@ import java.util.regex.Pattern;
 public class ChatUtil {
     private static final MiniMessage minimessage = MiniMessage.builder().build();
 
-    @SuppressWarnings("all")
-    public static String hexString(String message) {
-        Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
-        Matcher matcher = pattern.matcher(message);
-        while (matcher.find()) {
-            String hexCode = message.substring(matcher.start(), matcher.end());
-            String replaceSharp = hexCode.replace("&", "").replace('#', 'x');
-
-            char[] ch = replaceSharp.toCharArray();
-            StringBuilder builder = new StringBuilder();
-            for (char c : ch) {
-                builder.append("&" + c);
-            }
-
-            message = message.replace(hexCode, builder.toString());
-            matcher = pattern.matcher(message);
-        }
-        return ChatColor.translateAlternateColorCodes('&', message);
-    }
-
+    // Used to format chat-messages (legacy-support) of a specific sender related to his permissions
     public static Component validatedHexComp(CommandSender sender, String message) {
         message = message.replace("§", "&");
         message = parseHexColorCodes(message);
-        message = parseNativeColorCodes(message);
+        message = parseEasyToComplex(message);
         message = validateMinimessage(sender, message);
         return minimessage.deserialize(message);
     }
 
+    // Used to format a chat-messages (legacy-support) without previous validation of somebody.
     public static Component hexComp(String message) {
         message = message.replace("§", "&");
         message = parseHexColorCodes(message);
-        message = parseNativeColorCodes(message);
+        message = parseEasyToComplex(message);
         return minimessage.deserialize(message);
     }
 
+    // Parses legacy hex-colors to MiniMessage hex-colors
     private static String parseHexColorCodes(String message) {
         Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
         Matcher matcher = pattern.matcher(message);
@@ -59,6 +41,7 @@ public class ChatUtil {
         return message;
     }
 
+    // Parses legacy native-colors to MiniMessage native-colors
     private static String parseNativeColorCodes(String message) {
         Pattern pattern = Pattern.compile("&[a-flmnokrA-F0-9]");
         Matcher matcher = pattern.matcher(message);
@@ -72,68 +55,119 @@ public class ChatUtil {
         return message;
     }
 
-    public static Component fixColor(String message, String key, String value) {
-        if (message.split(key).length == 0)
-            return ChatUtil.hexComp(value);
-
-        String colorMsg = message.split(key)[0];
-        String color = colorMsg.substring(colorMsg.length() - 2);
-        if (color.trim().isEmpty())
-            return ChatUtil.hexComp(value);
-        if (color.charAt(0) == '&')
-            return ChatUtil.hexComp(color + value);
-        else return ChatUtil.hexComp(value);
+    private static String parseEasyToComplex(String message) {
+        message = message.replace("&0", "<color:black>");
+        message = message.replace("&1", "<color:dark_blue>");
+        message = message.replace("&2", "<color:dark_green>");
+        message = message.replace("&3", "<color:dark_aqua>");
+        message = message.replace("&4", "<color:dark_red>");
+        message = message.replace("&5", "<color:dark_purple>");
+        message = message.replace("&6", "<color:gold>");
+        message = message.replace("&7", "<color:gray>");
+        message = message.replace("&8", "<color:dark_gray>");
+        message = message.replace("&9", "<color:blue>");
+        message = message.replace("&a", "<color:green>");
+        message = message.replace("&b", "<color:aqua>");
+        message = message.replace("&c", "<color:red>");
+        message = message.replace("&d", "<color:light_purple>");
+        message = message.replace("&e", "<color:yellow>");
+        message = message.replace("&f", "<color:white>");
+        message = message.replace("&l", "<bold>");
+        message = message.replace("&m", "<strikethrough>");
+        message = message.replace("&n", "<u>");
+        message = message.replace("&o", "<italic>");
+        message = message.replace("&k", "<obf>");
+        message = message.replace("&r", "<reset>");
+        message = message.replace("<red>", "<color:red>");
+        message = message.replace("<green>", "<color:green>");
+        message = message.replace("<blue>", "<color:blue>");
+        message = message.replace("<yellow>", "<color:yellow>");
+        message = message.replace("<aqua>", "<color:aqua>");
+        message = message.replace("<gold>", "<color:gold>");
+        message = message.replace("<gray>", "<color:gray>");
+        message = message.replace("<dark_gray>", "<color:dark_gray>");
+        message = message.replace("<dark_red>", "<color:dark_red>");
+        message = message.replace("<dark_green>", "<color:dark_green>");
+        message = message.replace("<dark_blue>", "<color:dark_blue>");
+        message = message.replace("<dark_aqua>", "<color:dark_aqua>");
+        message = message.replace("<dark_purple>", "<color:dark_purple>");
+        message = message.replace("<light_purple>", "<color:light_purple>");
+        message = message.replace("<black>", "<color:black>");
+        message = message.replace("<white>", "<color:white>");
+        return message;
     }
 
+    // Returns the MiniMessage color-code for a specific native-color. It also resets the color when the char is 'r'
     private static String getNativeColor(char color) {
-        String reset = "<!b><!i><!obf><!u><!st>";
+        String reset = "<reset>";
         String colorCode = "<color:white>";
         if (color == 'r') return reset + colorCode;
         switch (color) {
             case 'a':
                 colorCode = "<color:green>";
+                break;
             case 'b':
                 colorCode = "<color:aqua>";
+                break;
             case 'c':
                 colorCode = "<color:red>";
+                break;
             case 'd':
                 colorCode = "<color:light_purple>";
+                break;
             case 'e':
                 colorCode = "<color:yellow>";
+                break;
             case 'f':
                 colorCode = "<color:white>";
+                break;
             case '0':
                 colorCode = "<color:black>";
+                break;
             case '1':
                 colorCode = "<color:dark_blue>";
+                break;
             case '2':
                 colorCode = "<color:dark_green>";
+                break;
             case '3':
                 colorCode = "<color:dark_aqua>";
+                break;
             case '4':
                 colorCode = "<color:dark_red>";
+                break;
             case '5':
                 colorCode = "<color:dark_purple>";
+                break;
             case '6':
                 colorCode = "<color:gold>";
+                break;
             case '7':
                 colorCode = "<color:gray>";
+                break;
             case '8':
                 colorCode = "<color:dark_gray>";
+                break;
             case '9':
                 colorCode = "<color:blue>";
+                break;
             case 'l':
                 colorCode = "<bold>";
+                break;
             case 'm':
                 colorCode = "<strikethrough>";
+                break;
             case 'n':
                 colorCode = "<u>";
+                break;
             case 'o':
                 colorCode = "<italic>";
+                break;
             case 'k':
                 colorCode = "<obf>";
+                break;
         }
-        switch (color) {
+        /*switch (color) {
             case 'l':
             case 'm':
             case 'n':
@@ -142,13 +176,23 @@ public class ChatUtil {
                 break;
             default:
                 colorCode = reset + colorCode;
-        }
+        }*/
         return colorCode;
     }
 
+    // Validates a minimessage for a specific sender, meaning we check for permissions and remove components if necessary
     private static String validateMinimessage(CommandSender sender, String message) {
 
+        /*
         // Check if there is a link in the message without click-component
+        Pattern pattern = Pattern.compile("(?<!<click:open_url:)(https?://\\S+)(?!>)");
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            String link = message.substring(matcher.start(), matcher.end());
+            message = message.replace(link, "<click:open_url:" + link + ">" + link + "</click>");
+            matcher = pattern.matcher(message);
+        }*/
+
         Pattern pattern = Pattern.compile("https?://\\S+");
         Matcher matcher = pattern.matcher(message);
         while (matcher.find()) {
@@ -252,7 +296,6 @@ public class ChatUtil {
                 break;
             }
         }
-
         return message;
     }
 }

--- a/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/ChatUtil.java
@@ -1,0 +1,243 @@
+package me.ryanhamshire.GPFlags.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ChatUtil {
+    private static final MiniMessage minimessage = MiniMessage.builder().build();
+
+    @SuppressWarnings("all")
+    public static String hexString(String message) {
+        Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            String hexCode = message.substring(matcher.start(), matcher.end());
+            String replaceSharp = hexCode.replace("&", "").replace('#', 'x');
+
+            char[] ch = replaceSharp.toCharArray();
+            StringBuilder builder = new StringBuilder();
+            for (char c : ch) {
+                builder.append("&" + c);
+            }
+
+            message = message.replace(hexCode, builder.toString());
+            matcher = pattern.matcher(message);
+        }
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    public static Component validatedHexComp(CommandSender sender, String message) {
+        message = message.replace("§", "&");
+        message = parseHexColorCodes(message);
+        message = parseNativeColorCodes(message);
+        message = validateMinimessage(sender, message);
+        return minimessage.deserialize(message);
+    }
+
+    public static Component hexComp(String message) {
+        message = message.replace("§", "&");
+        message = parseHexColorCodes(message);
+        message = parseNativeColorCodes(message);
+        return minimessage.deserialize(message);
+    }
+
+    private static String parseHexColorCodes(String message) {
+        Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            String hexCode = message.substring(matcher.start(), matcher.end());
+            String replaceSharp = hexCode.replace("&", "");
+
+            message = message.replace(hexCode, "<color:" + replaceSharp + ">");
+            matcher = pattern.matcher(message);
+        }
+        return message;
+    }
+
+    private static String parseNativeColorCodes(String message) {
+        Pattern pattern = Pattern.compile("&[a-flmnokrA-F0-9]");
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            String colorCode = message.substring(matcher.start(), matcher.end());
+            String replaceSharp = colorCode.replace("&", "");
+
+            message = message.replace(colorCode, getNativeColor(replaceSharp.toCharArray()[0]));
+            matcher = pattern.matcher(message);
+        }
+        return message;
+    }
+
+    public static Component fixColor(String message, String key, String value) {
+        if (message.split(key).length == 0)
+            return ChatUtil.hexComp(value);
+
+        String colorMsg = message.split(key)[0];
+        String color = colorMsg.substring(colorMsg.length() - 2);
+        if (color.trim().isEmpty())
+            return ChatUtil.hexComp(value);
+        if (color.charAt(0) == '&')
+            return ChatUtil.hexComp(color + value);
+        else return ChatUtil.hexComp(value);
+    }
+
+    private static String getNativeColor(char color) {
+        String reset = "<!b><!i><!obf><!u><!st>";
+        String colorCode = "<color:white>";
+        if (color == 'r') return reset + colorCode;
+        switch (color) {
+            case 'a':
+                colorCode = "<color:green>";
+            case 'b':
+                colorCode = "<color:aqua>";
+            case 'c':
+                colorCode = "<color:red>";
+            case 'd':
+                colorCode = "<color:light_purple>";
+            case 'e':
+                colorCode = "<color:yellow>";
+            case 'f':
+                colorCode = "<color:white>";
+            case '0':
+                colorCode = "<color:black>";
+            case '1':
+                colorCode = "<color:dark_blue>";
+            case '2':
+                colorCode = "<color:dark_green>";
+            case '3':
+                colorCode = "<color:dark_aqua>";
+            case '4':
+                colorCode = "<color:dark_red>";
+            case '5':
+                colorCode = "<color:dark_purple>";
+            case '6':
+                colorCode = "<color:gold>";
+            case '7':
+                colorCode = "<color:gray>";
+            case '8':
+                colorCode = "<color:dark_gray>";
+            case '9':
+                colorCode = "<color:blue>";
+            case 'l':
+                colorCode = "<bold>";
+            case 'm':
+                colorCode = "<strikethrough>";
+            case 'n':
+                colorCode = "<u>";
+            case 'o':
+                colorCode = "<italic>";
+            case 'k':
+                colorCode = "<obf>";
+        }
+        switch (color) {
+            case 'l':
+            case 'm':
+            case 'n':
+            case 'o':
+            case 'k':
+                break;
+            default:
+                colorCode = reset + colorCode;
+        }
+        return colorCode;
+    }
+
+    private static String validateMinimessage(CommandSender sender, String message) {
+
+        // Check for click-components
+        Pattern pattern = Pattern.compile("<click:.*?>");
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            boolean requiredChanges = false;
+            String clickComponent = message.substring(matcher.start(), matcher.end());
+            if (clickComponent.contains("suggest_command") && !sender.hasPermission("gpflags.messages.click.suggest_command")) {
+                message = message.replace(clickComponent, "");
+                requiredChanges = true;
+            }
+            if (clickComponent.contains("run_command") && !sender.hasPermission("gpflags.messages.click.run_command")) {
+                message = message.replace(clickComponent, "");
+                requiredChanges = true;
+            }
+            if (clickComponent.contains("open_url") && !sender.hasPermission("gpflags.messages.click.open_url")) {
+                message = message.replace(clickComponent, "");
+                requiredChanges = true;
+            }
+            matcher = pattern.matcher(message);
+
+            if (!requiredChanges) {
+                break;
+            }
+        }
+
+        // Check for hover-components
+        pattern = Pattern.compile("<hover:.*?>");
+        matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            boolean requiredChanges = false;
+
+            String hoverComponent = message.substring(matcher.start(), matcher.end());
+            if (hoverComponent.contains("show_text") && !sender.hasPermission("gpflags.messages.hover.show_text")) {
+                message = message.replace(hoverComponent, "");
+                requiredChanges = true;
+            }
+            if (hoverComponent.contains("show_item") && !sender.hasPermission("gpflags.messages.hover.show_item")) {
+                message = message.replace(hoverComponent, "");
+                requiredChanges = true;
+            }
+            if (hoverComponent.contains("show_entity") && !sender.hasPermission("gpflags.messages.hover.show_entity")) {
+                message = message.replace(hoverComponent, "");
+                requiredChanges = true;
+            }
+            matcher = pattern.matcher(message);
+
+            if (!requiredChanges) {
+                break;
+            }
+        }
+
+        // Check for hex-colors
+        message = message.replace("<#", "<color:#");
+        pattern = Pattern.compile("<color:#.*?>");
+        matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            boolean requiredChanges = false;
+            String hexComponent = message.substring(matcher.start(), matcher.end());
+            if(!sender.hasPermission("gpflags.messages.hex-colors")) {
+                message = message.replace(hexComponent, "<color:white>");
+                requiredChanges = true;
+            }
+            matcher = pattern.matcher(message);
+
+            if (!requiredChanges) {
+                break;
+            }
+        }
+
+        // Check for colors
+        message = ChatUtil.parseNativeColorCodes(message);
+        pattern = Pattern.compile("<color:.*?>");
+        matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            boolean requiredChanges = false;
+            String colorComponent = message.substring(matcher.start(), matcher.end());
+            if(!sender.hasPermission("gpflags.messages.colors")) {
+                message = message.replace(colorComponent, "");
+                requiredChanges = true;
+            }
+            matcher = pattern.matcher(message);
+
+            if (!requiredChanges) {
+                break;
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/me/ryanhamshire/GPFlags/util/MessagingUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/MessagingUtil.java
@@ -51,7 +51,7 @@ public class MessagingUtil {
             message = PlaceholderApiHook.addPlaceholders(player, message);
         } catch (Throwable ignored) {}
         message = message.replace(COLOR_CHAR, '&');
-        Component component = ChatUtil.validatedHexComp(receiver, message);
+        Component component = ChatUtil.hexComp(message);
         GPFlags.getInstance().getAdventure().player(player).sendMessage(component);
 //        Audience.audience(player).sendMessage(component);
     }

--- a/src/main/java/me/ryanhamshire/GPFlags/util/MessagingUtil.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/util/MessagingUtil.java
@@ -6,7 +6,6 @@ import me.ryanhamshire.GPFlags.Messages;
 import me.ryanhamshire.GPFlags.hooks.PlaceholderApiHook;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
@@ -52,7 +51,7 @@ public class MessagingUtil {
             message = PlaceholderApiHook.addPlaceholders(player, message);
         } catch (Throwable ignored) {}
         message = message.replace(COLOR_CHAR, '&');
-        Component component = MiniMessage.miniMessage().deserialize(message);
+        Component component = ChatUtil.validatedHexComp(receiver, message);
         GPFlags.getInstance().getAdventure().player(player).sendMessage(component);
 //        Audience.audience(player).sendMessage(component);
     }
@@ -64,7 +63,7 @@ public class MessagingUtil {
 
     public static void sendActionbar(Player player, String message) {
         message = message.replace(COLOR_CHAR, '&');
-        Component component = MiniMessage.miniMessage().deserialize(message);
+        Component component = ChatUtil.hexComp(message);
         GPFlags.getInstance().getAdventure().player(player).sendActionBar(component);
     }
 
@@ -94,7 +93,7 @@ public class MessagingUtil {
 
     public static String reserialize(String ampersandMessage) {
         ampersandMessage = convertOriginalHexColors(ampersandMessage);
-        Component component = LegacyComponentSerializer.legacyAmpersand().deserialize(ampersandMessage);
+        Component component = ChatUtil.hexComp(ampersandMessage);
         return MiniMessage.miniMessage().serialize(component);
     }
 }


### PR DESCRIPTION
Related to #78:
- Transform the old legacy color codes into proper minimessages
- Also does the same with links without <click>- component
- New Permissions for further customization:
## Click-Components
  - `gpflags.messages.click.suggest_command` - Allows the suggest_command value of click-component
  - `gpflags.messages.click.run_command` - Allows the run_command value of click-component
  - `gpflags.messages.click.run_command` - Allows the run_command value of click-component
## Hover-Components
  - `gpflags.messages.hover.show_text` - Allows the show_textvalue of hover-component
  - `gpflags.messages.hover.show_item` - Allows the show_itemvalue of hover-component
  - `gpflags.messages.hover.show_entity` - Allows the show_entityvalue of hover-component
 ## Others
  - `gpflags.messages.hex-colors` - Allows the use of hex-colors in minimessages
  - `gpflags.messages.colors` - Allows the use of default colors (former legacy codes) in minimessages
  - [EDIT] `gpflags.messages.style.bold` - Allows usage of bold messages
  - [EDIT] `gpflags.messages.style.underlined` - Allows usage of underlinedmessages
  - [EDIT] `gpflags.messages.style.italic` - Allows usage of italicmessages
  - [EDIT] `gpflags.messages.style.strikethrough` - Allows usage of strikethrough messages
  - [EDIT] `gpflags.messages.style.obfuscated` - Allows usage of obfuscated messages
  - [EDIT] ~~`gpflags.messages.links` : Allow using legacy links without `<click:open_url:...>`~~